### PR TITLE
 Startup configuration options

### DIFF
--- a/src/AspNetCore.VersionInfo/Configuration/ExclusionSettings.cs
+++ b/src/AspNetCore.VersionInfo/Configuration/ExclusionSettings.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AspNetCore.VersionInfo.Configuration
+{
+    public class ExclusionSettings
+    {
+        public IEnumerable<string> Keys { get; set; }
+    }
+}

--- a/src/AspNetCore.VersionInfo/Configuration/ExclusionSettingsService.cs
+++ b/src/AspNetCore.VersionInfo/Configuration/ExclusionSettingsService.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AspNetCore.VersionInfo.Configuration
+{
+    public class ExclusionSettingsService : IExclusionSettings
+    {
+        public IEnumerable<string> keys { get; set; }
+        public ExclusionSettingsService(List<String> keys)
+        {
+            this.keys = keys;
+        }
+    }
+}

--- a/src/AspNetCore.VersionInfo/Configuration/IExclusionSettings.cs
+++ b/src/AspNetCore.VersionInfo/Configuration/IExclusionSettings.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AspNetCore.VersionInfo.Configuration
+{
+    public interface IExclusionSettings
+    {
+        IEnumerable<string> keys { get; set; }
+    }
+}

--- a/src/AspNetCore.VersionInfo/Extensions/VersionInfoBuilderExtensions.cs
+++ b/src/AspNetCore.VersionInfo/Extensions/VersionInfoBuilderExtensions.cs
@@ -1,12 +1,36 @@
-﻿using AspNetCore.VersionInfo.Providers;
+﻿using System;
+using System.Collections.Generic;
+using AspNetCore.VersionInfo.Configuration;
+using AspNetCore.VersionInfo.Providers;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AspNetCore.VersionInfo
 {
     public static class VersionInfoBuilderExtensions
     {
-        public static VersionInfoBuilder With<T>(this VersionInfoBuilder builder) where T : class, IInfoProvider
+        private static List<String> keyValues = new List<String>();
+        public static VersionInfoBuilder With<T>(this VersionInfoBuilder builder, Action<ExclusionSettings> configureOptions = null) where T : class, IInfoProvider
         {
+
+            if (configureOptions != null)
+            {
+                var settings = new ExclusionSettings();
+
+                configureOptions(settings);
+
+                foreach (var keyItem in settings.Keys)
+                {
+                    keyValues.Add(keyItem);
+                }
+            }
+
+            builder.Services.AddTransient<IExclusionSettings>(serviceProvider =>
+            {
+
+                return new ExclusionSettingsService(keyValues);
+
+            });
+
             builder.Services.AddTransient<IInfoProvider, T>();
             return builder;
         }


### PR DESCRIPTION
In the Startup.cs file we can use the below configuration to exclude some of sensitive contents
Example.

```
 public void ConfigureServices(IServiceCollection services)
        {
       
            services.AddVersionInfo()
                .With<ClrVersionProvider>(option => option.Keys = new string[] { "RuntimeInformation.ProcessArchitecture", "RuntimeInformation.RuntimeIdentifier" });
                
        }
```
Result of the above configuration:

```
{
  "Results": [
    {
      "ProviderName": "ClrVersionProvider",
      "Key": "RuntimeInformation.FrameworkDescription",
      "Value": ".NET 6.0.10"
    },
    {
      "ProviderName": "ClrVersionProvider",
      "Key": "RuntimeInformation.OsDescription",
      "Value": "Microsoft Windows 10.0.19044"
    },
    {
      "ProviderName": "ClrVersionProvider",
      "Key": "RuntimeInformation.OsArchitecture",
      "Value": "X64"
    },
    {
      "ProviderName": "ClrVersionProvider",
      "Key": "Environment.DotNetVersion",
      "Value": "6.0.10"
    }
  ],
  "Count": 4
}
```

 We can add all as well.
 
```
 public void ConfigureServices(IServiceCollection services)
        {
           
            services.AddVersionInfo()
                .With<ClrVersionProvider>(option => option.Keys = new string[] { "RuntimeInformation.ProcessArchitecture", "RuntimeInformation.RuntimeIdentifier" })
                .With<AssemblyVersionProvider>()
                .With<AppDomainAssembliesVersionProvider>()
                .With<EnvironmentProvider>()
                .With<EnvironmentVariablesProvider>();
        }

```
The final example is.

```
  public void ConfigureServices(IServiceCollection services)
        {

            services.AddVersionInfo()
                    .With<ClrVersionProvider>(op => op.Keys = new string[] { "RuntimeInformation.ProcessArchitecture", "RuntimeInformation.RuntimeIdentifier" })
                    .With<AssemblyVersionProvider>(op => op.Keys = new string[] { "EntryAssemblyFileVersion" })
                    .With<AppDomainAssembliesVersionProvider>(option => option.Keys = new string[] { "Basic", "Anonymously Hosted DynamicMethods Assembly", "Basic.Views", "AspNetCore.VersionInfo" })
                    .With<EnvironmentProvider>()
                    .With<EnvironmentVariablesProvider>(option => option.Keys = new string[] { "Environment.Is64BitOperatingSystem" });
        }
```